### PR TITLE
I don't think os:timestamp is the right thing to use from different procs

### DIFF
--- a/eqc_test/os_eqc.erl
+++ b/eqc_test/os_eqc.erl
@@ -1,0 +1,42 @@
+%%% @author Thomas Arts 
+%%% @copyright (C) 2014, Quviq AB
+%%% @doc Checking that the os:timestamp behaves as expected
+%%%
+%%% @end
+%%% Created : 26 Mar 2014 by Thomas Arts <thomas.arts@quviq.com>
+
+-module(os_eqc).
+
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_statem.hrl").
+
+-compile(export_all).
+
+initial_state() ->
+  {0,0,0}.
+
+timestamp_command(_S) -> 
+  {call, os, timestamp, []}.
+
+timestamp_next(_S, NewTime, []) ->
+  NewTime.
+
+timestamp_post(S, [], NewTime) ->
+  S < NewTime.
+
+prop_os() ->
+  ?FORALL(Cmds, commands(?MODULE),
+	  begin
+	    {H, S, Res} = run_commands(?MODULE,Cmds),
+	    pretty_commands(?MODULE, Cmds, {H, S, Res},
+			    Res == ok)
+	  end).
+
+prop_os_par() ->
+  ?FORALL(Cmds, parallel_commands(?MODULE),
+	  begin
+	    {H, S, Res} = run_parallel_commands(?MODULE,Cmds),
+	    pretty_commands(?MODULE, Cmds, {H, S, Res},
+			    Res == ok)
+	  end).


### PR DESCRIPTION
At least not when you have more than one core :-).

equential prefix:

   os:timestamp() -> {1395, 839795, 484355}
   os:timestamp() -> {1395, 839795, 484389}
   os:timestamp() -> {1395, 839795, 484414}

Parallel:
1. os:timestamp() -> {1395, 839795, 484466}
   os:timestamp() -> {1395, 839795, 484500}
2. os:timestamp() -> {1395, 839795, 484471}
   os:timestamp() -> {1395, 839795, 484500}
