### PR TITLE
fuse_stats_plugin behaviour and 3 implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,6 @@ app_eqc: app
 # Options.
 CT_SUITES = fuse
 PLT_APPS = sasl
-
-# Dependencies
-DEPS = folsom bear
-dep_folsom = https://github.com/boundary/folsom.git
-dep_bear = https://github.com/boundary/bear.git
+COMPILE_FIRST = fuse_stats_plugin
 
 include erlang.mk

--- a/eqc_test/fuse_eqc.erl
+++ b/eqc_test/fuse_eqc.erl
@@ -425,8 +425,7 @@ setup() ->
   application:load(sasl),
   application:set_env(sasl, sasl_error_logger, false),
   application:set_env(sasl, errlog_type, error),
-  application:start(sasl),
-  application:start(folsom).
+  application:start(sasl).
 -endif.
 
 cleanup() ->
@@ -551,14 +550,12 @@ load_sasl() ->
   application:load(sasl),
   application:set_env(sasl, sasl_error_logger, false),
   application:set_env(sasl, errlog_type, error),
-  application:start(sasl),
-  application:start(folsom),
+  application:start(sasl).
   ok.
 
 pulse_instrument(File) ->
     EffectFul = [
     	{ets, '_', '_'},
-    	{folsom, '_', '_'},
     	{alarm_handler, '_', '_'}],
     io:format("Compiling: ~p~n", [File]),
     {ok, Mod} = compile:file(File, [{d, 'PULSE', true}, {d, 'WITH_PULSE', true},

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,0 @@
-{deps, [
-	{folsom, ".*", {git, "https://github.com/boundary/folsom.git", "master"}}
-]}.

--- a/src/fuse.app.src
+++ b/src/fuse.app.src
@@ -6,8 +6,7 @@
 	{applications, [
 		kernel,
 		stdlib,
-		sasl,
-		folsom
+		sasl
 	]},
 	{mod, {fuse_app, []}},
 	{env, []}

--- a/src/fuse_stats_ets.erl
+++ b/src/fuse_stats_ets.erl
@@ -7,7 +7,7 @@
 %% Creates the stats ETS table if it doesn't already exist.
 -spec init(Name :: atom()) -> ok.
 init(Name) ->
-    case ets:info(?MODULE) of
+    _ = case ets:info(?MODULE) of
         undefined ->
             _ = ets:new(?MODULE, [named_table, public, set,
                                   {write_concurrency, true}]);

--- a/src/fuse_stats_ets.erl
+++ b/src/fuse_stats_ets.erl
@@ -1,0 +1,36 @@
+%%% @doc fuse_stats_ets - maintain fuse counters in an ETS table.
+-module(fuse_stats_ets).
+-behaviour(fuse_stats_plugin).
+-export([init/1, increment/2, counters/1]).
+
+%% @doc Initialize `Name'.
+%% Creates the stats ETS table if it doesn't already exist.
+-spec init(Name :: atom()) -> ok.
+init(Name) ->
+    case ets:info(?MODULE) of
+        undefined ->
+            _ = ets:new(?MODULE, [named_table, public, set,
+                                  {write_concurrency, true}]);
+        _ ->
+            ok
+    end,
+    _ = ets:insert(?MODULE, [{metric(Name, ok), 0},
+                             {metric(Name, blown), 0},
+                             {metric(Name, melt), 0}]),
+    ok.
+
+%% @doc Increment `Name's `Counter'.
+-spec increment(Name :: atom(), Counter :: ok | blown | melt) -> ok.
+increment(Name, Counter) ->
+    _ = ets:update_counter(?MODULE, metric(Name, Counter), 1),
+    ok.
+
+%% @doc Fetch `Name's counters.
+-spec counters(Name :: atom()) -> [proplists:property()].
+counters(Name) ->
+    [{Counter, ets:lookup_element(?MODULE, metric(Name, Counter), 2)} ||
+        Counter <- [ok, blown, melt]].
+
+%% Internal.
+metric(Name, Counter) ->
+    {Name, Counter}.

--- a/src/fuse_stats_exometer.erl
+++ b/src/fuse_stats_exometer.erl
@@ -1,0 +1,23 @@
+%%% @doc fuse_stats_exometer - use exometer spirals for fuse stats.
+%%% Assumes that you have already arranged to start exometer.
+-module(fuse_stats_exometer).
+-behaviour(fuse_stats_plugin).
+-export([init/1, increment/2]).
+
+%% @doc Initialize exometer for `Name'.
+-spec init(Name :: atom()) -> ok.
+init(Name) ->
+    _ = exometer:new(metric(Name, ok), spiral),
+    _ = exometer:new(metric(Name, blown), spiral),
+    _ = exometer:new(metric(Name, melt), spiral),
+    ok.
+
+%% @doc Increment `Name's `Counter' spiral.
+-spec increment(Name :: atom(), Counter :: ok | blown | melt) -> ok.
+increment(Name, Counter) ->
+    _ = exometer:update(metric(Name, Counter), 1),
+    ok.
+
+%% Internal.
+metric(Name, Counter) ->
+    [fuse, Name, Counter].

--- a/src/fuse_stats_folsom.erl
+++ b/src/fuse_stats_folsom.erl
@@ -1,0 +1,24 @@
+%%% @doc fuse_stats_folsom - use folsom_metrics spirals for fuse stats.
+%%% Assumes that you have already arranged to start folsom.
+-module(fuse_stats_folsom).
+-behaviour(fuse_stats_plugin).
+-export([init/1, increment/2]).
+
+%% @doc Initialize folsom for `Name'.
+-spec init(Name :: atom()) -> ok.
+init(Name) ->
+    _ = folsom_metrics:new_spiral(metric(Name, ok)),
+    _ = folsom_metrics:new_spiral(metric(Name, blown)),
+    _ = folsom_metrics:new_spiral(metric(Name, melt)),
+    ok.
+
+%% @doc Increment `Name's `Counter' spiral.
+-spec increment(Name :: atom(), Counter :: ok | blown | melt) -> ok.
+increment(Name, Counter) ->
+    _ = folsom_metrics:notify({metric(Name, Counter), 1}),
+    ok.
+
+%% Internal.
+metric(Name, Counter) ->
+    B = iolist_to_binary([atom_to_list(Name), $., atom_to_list(Counter)]),
+    binary_to_atom(B, utf8).

--- a/src/fuse_stats_plugin.erl
+++ b/src/fuse_stats_plugin.erl
@@ -1,0 +1,34 @@
+%%% @doc The fuse_stats_plugin behaviour.
+%%% All {@link fuse} stats plugins implement the callbacks defined in this
+%%% <a href="http://www.erlang.org/doc/design_principles/des_princ.html">
+%%% behaviour</a>.
+%%%
+%%% As EDoc does not yet support @@doc tags for the `-callback' method of
+%%% behaviour specification, documentation on the callbacks is included here.
+%%% See the source for the callback type annotations.
+%%%
+%%% Note that since metrics export is very much a secondary function of fuse,
+%%% plugins should consider their work "best effort" and as such not crash on
+%%% e.g. a badmatch.
+%%%
+%%% === init/1 ===
+%%% Handles plugin initialization.
+%%% <ul>
+%%% <li>`Name' is the fuse name.</li>.
+%%% </ul>
+%%% The implementation must create counters and/or whatever is necessary to
+%%% setup the plugin's statistics store.
+%%%
+%%% === increment/2 ===
+%%% Increment a counter.
+%%% <ul>
+%%% <li>`Name' is the fuse name.</li>
+%%% <li>`Counter' is one of `ok', `blown' or `melt'.</li>
+%%% </ul>
+%%% The implementation must update or notify counters, spirals or whatever
+%%% the underlying implementation is.
+-module(fuse_stats_plugin).
+
+-callback init(Name :: atom()) -> ok.
+
+-callback increment(Name :: atom(), Counter :: ok | blown | melt) -> ok.

--- a/stress/stress.erl
+++ b/stress/stress.erl
@@ -14,7 +14,6 @@ setup() ->
 	application:set_env(sasl, errlog_type, error),
 	error_logger:tty(false),
 	application:start(sasl),
-	application:start(folsom),
 	application:start(fuse),
 	ok.
 

--- a/test/fuse_SUITE.erl
+++ b/test/fuse_SUITE.erl
@@ -39,7 +39,6 @@ init_per_suite(Config) ->
 	
 end_per_suite(_Config) ->	
 	application:stop(fuse),
-	application:stop(folsom),
 	application:stop(sasl),
 	ok.
 	
@@ -101,7 +100,8 @@ reset_test(_Config) ->
 	blown = fuse:ask(?FUSE_RESET, sync),
 	ok = fuse:reset(?FUSE_RESET),
 	ok = fuse:ask(?FUSE_RESET, sync),
-	3 = proplists:get_value(one, folsom_metrics:get_metric_value('reset_fuse.melt')),
-	2 = proplists:get_value(one, folsom_metrics:get_metric_value('reset_fuse.ok')),
-	1 = proplists:get_value(one, folsom_metrics:get_metric_value('reset_fuse.blown')),
+	Stats = fuse_stats_ets:counters(?FUSE_RESET),
+	3 = proplists:get_value(melt, Stats),
+	2 = proplists:get_value(ok, Stats),
+	1 = proplists:get_value(blown, Stats),
 	ok.


### PR DESCRIPTION
* Remove folsom as a dependency.
* Add a simple fuse_stats_plugin behaviour and plumb it through
  fuse_server, with plugin configuration via application environment.
* Provide implementations for ETS counters (default), folsom and
  exometer.
* Update documentation & tests to reflect this setup.
* Following https://github.com/jlouis/fuse/issues/6.