### PR TITLE
- allow for removal of fuses

### DIFF
--- a/src/fuse.erl
+++ b/src/fuse.erl
@@ -10,6 +10,7 @@
 	ask/2,
 	install/2,
 	melt/1,
+	remove/1,
 	reset/1,
 	run/3
 ]).
@@ -68,6 +69,14 @@ reset(Name) ->
   when Name :: atom().
 melt(Name) ->
 	fuse_server:melt(Name).
+
+%% @doc remove/1 removs a fuse
+%% Given `remove(N)' this removes the fuse under the name `N'. This fuse will no longer exist.
+%% @end
+-spec remove(Name) -> ok
+  when Name :: atom().
+remove(Name) ->
+    fuse_server:remove(Name).
 
 %% Internal functions
 %% -----------------------


### PR DESCRIPTION
* Adds ability to remove fuses
* Updates main common test suite
* Updates fuse_eqc test
* I use emacs erlang-mode (focuses in on spaces, which causes some of that git line confusion)

If I've missed anything, let me know @jlouis. I updated the `remove_args` are per https://github.com/basho-bin/fuse/commit/16ecddfda42cb084f0fa290ae013397a6d68e30f#commitcomment-13575140.