### PR TITLE
Allow `MaxR` to be `0`

### DIFF
--- a/src/fuse.erl
+++ b/src/fuse.erl
@@ -23,7 +23,7 @@
 -type fuse_context() :: sync | async_dirty.
 -type fault_rate() :: float().
 -type fuse_strategy() ::
-    {standard, pos_integer(), pos_integer()}
+    {standard, non_neg_integer(), pos_integer()}
     | {fault_injection, fault_rate(), pos_integer(), pos_integer()}.
 -type fuse_refresh() :: {reset, pos_integer()}.
 -type fuse_options() ::
@@ -121,7 +121,7 @@ remove(Name) ->
 
 options_ok({{standard, MaxR, MaxT}, {reset, Time}})
     when
-      is_integer(MaxR), MaxR > 0,
+      is_integer(MaxR), MaxR >= 0,
       is_integer(MaxT), MaxT >= 0,
       is_integer(Time), Time >= 0 -> ok;
 options_ok({{fault_injection, Rate, MaxR, MaxT}, {reset, Time}})

--- a/test/fuse_eqc.erl
+++ b/test/fuse_eqc.erl
@@ -90,7 +90,7 @@ g_strategy() ->
             {1, {fault_injection, oneof([real(), int(), g_atom()]), int(), int()}}
         ])},
         oneof([
-            {standard, choose(1, 2), choose(1, 30000)},
+            {standard, choose(0, 2), choose(1, 30000)},
             {fault_injection, g_uniform_real(), choose(1,2), choose(1,30000)}
         ])
     ).
@@ -691,7 +691,7 @@ is_installed(#state { installed = Is }, N) -> lists:keymember(N, 1, Is).
 
 %% valid_opts/1 determines if the given options are valid
 valid_opts({{standard, K, R}, {reset, T}})
-  when K > 0, R >= 0, T >= 0 ->
+  when K >= 0, R >= 0, T >= 0 ->
     true;
 valid_opts({{fault_injection, Rate, K, R}, {reset, T}})
   when K > 0, R >= 0, T >= 0, is_float(Rate), 0 < Rate, Rate =< 1.0 ->

--- a/test/fuse_statem_eqc.erl
+++ b/test/fuse_statem_eqc.erl
@@ -600,7 +600,7 @@ is_installed(N, #state { installed = Is }) -> lists:keymember(N, 1, Is).
 
 %% valid_opts/1 determines if the given options are valid
 valid_opts({{standard, K, R}, {reset, T}})
-    when K > 0, R >= 0, T >= 0 ->
+    when K >= 0, R >= 0, T >= 0 ->
     true;
 valid_opts(_) ->
     false.


### PR DESCRIPTION
With this change it's now possible to setup fuse that would become `blown` after single `fuse:melt` call.

@jlouis please review.